### PR TITLE
feat: persist user currency and streamline registration

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,9 +1,30 @@
-// UI logic for tabs (Registro / Ingreso)
 (function () {
   const tabRegister = document.getElementById('tab-register');
   const tabLogin = document.getElementById('tab-login');
   const registerForm = document.getElementById('register-form');
   const loginForm = document.getElementById('login-form');
+  const currencySection = document.getElementById('currency-section');
+  const currencySelect = document.getElementById('currency-select');
+  const amountInput = document.getElementById('amount');
+  const buyBtn = document.getElementById('buy-btn');
+  const title = document.getElementById('title');
+  const toast = document.getElementById('toast');
+  const neoBalance = document.getElementById('neo-balance');
+  const currencyDisplay = document.getElementById('currency-display');
+  const rateDiv = document.getElementById('rate');
+
+  const users = JSON.parse(localStorage.getItem('users') || '[]');
+  let currentUser = null;
+
+  function saveUsers() {
+    localStorage.setItem('users', JSON.stringify(users));
+  }
+
+  function showToast(msg) {
+    toast.textContent = msg;
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 3000);
+  }
 
   function activate(which) {
     const isRegister = which === 'register';
@@ -15,7 +36,122 @@
 
   tabRegister?.addEventListener('click', () => activate('register'));
   tabLogin?.addEventListener('click', () => activate('login'));
-
-  // default
   activate('register');
+
+  document.querySelectorAll('.toggle-password').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const input = document.getElementById(btn.dataset.target);
+      input.type = input.type === 'password' ? 'text' : 'password';
+    });
+  });
+
+  const displayNames = new Intl.DisplayNames(['es'], { type: 'currency' });
+  Intl.supportedValuesOf('currency').forEach(code => {
+    const option = document.createElement('option');
+    option.value = code;
+    option.textContent = `${code} - ${displayNames.of(code)}`;
+    currencySelect.appendChild(option);
+  });
+  currencySelect.value = 'USD';
+
+  function showCurrency() {
+    registerForm.style.display = 'none';
+    loginForm.style.display = 'none';
+    document.querySelector('.tabs').style.display = 'none';
+    currencySection.style.display = 'block';
+  }
+
+  function updateBalance() {
+    neoBalance.textContent = `${currentUser.balance} NEO`;
+  }
+
+  function updateCurrencyUI() {
+    const cur = currentUser?.currency || currencySelect.value || 'USD';
+    amountInput.placeholder = `Cantidad en ${cur}`;
+    rateDiv.textContent = `1 ${cur} = 4 NEO`;
+    currencyDisplay.textContent = `Divisa: ${cur}`;
+    const hasCurrency = !!currentUser?.currency;
+    currencyDisplay.style.display = hasCurrency ? 'block' : 'none';
+    currencySelect.style.display = hasCurrency ? 'none' : 'block';
+    if (hasCurrency) {
+      currencySelect.value = cur;
+    }
+  }
+
+  function loginUser(user) {
+    currentUser = user;
+    title.textContent = `${user.first} bienvenido a NEÓN-R`;
+    showCurrency();
+    updateBalance();
+    updateCurrencyUI();
+  }
+
+  registerForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const first = document.getElementById('reg-first').value.trim();
+    const last = document.getElementById('reg-last').value.trim();
+    const gender = document.getElementById('reg-gender').value;
+    const email = document.getElementById('reg-email').value.trim().toLowerCase();
+    const pass = document.getElementById('reg-password').value;
+    const pass2 = document.getElementById('reg-password2').value;
+
+    if (users.some(u => u.first.toLowerCase() === first.toLowerCase())) {
+      showToast('este nombre ya está registrado');
+      return;
+    }
+    if (users.some(u => u.email === email)) {
+      showToast('este correo ya existe');
+      return;
+    }
+    if (!/^(?=.*[A-Za-z])(?=.*\d).{8,}$/.test(pass)) {
+      showToast('la contraseña debe tener 8 letras y un número');
+      return;
+    }
+    if (pass !== pass2) {
+      showToast('las contraseñas no coinciden');
+      return;
+    }
+
+    const user = { first, last, gender, email, pass, balance: 0, currency: null };
+    users.push(user);
+    saveUsers();
+    loginUser(user);
+  });
+
+  loginForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const email = document.getElementById('login-email').value.trim().toLowerCase();
+    const pass = document.getElementById('login-password').value;
+    const user = users.find(u => u.email === email);
+    if (!user) {
+      showToast('este correo no existe');
+      return;
+    }
+    if (user.pass !== pass) {
+      showToast('contraseña incorrecta');
+      return;
+    }
+    loginUser(user);
+  });
+
+  currencySelect.addEventListener('change', () => {
+    if (!currentUser) return;
+    currentUser.currency = currencySelect.value;
+    saveUsers();
+    updateCurrencyUI();
+  });
+
+  buyBtn.addEventListener('click', () => {
+    const amount = parseFloat(amountInput.value);
+    if (isNaN(amount) || amount <= 0) {
+      showToast('ingresa una cantidad válida');
+      return;
+    }
+    const neo = Math.round(amount * 4);
+    currentUser.balance += neo;
+    saveUsers();
+    updateBalance();
+    showToast(`compraste ${neo} NEO`);
+  });
 })();
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -119,6 +119,69 @@
       margin-top: 10px;
     }
 
+    .password-wrapper {
+      position: relative;
+    }
+    .toggle-password {
+      position: absolute;
+      right: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+      cursor: pointer;
+    }
+
+    .toggle-password svg {
+      width: 20px;
+      height: 20px;
+      stroke: #d4af37;
+      fill: none;
+    }
+
+    .toggle-password svg circle {
+      fill: #d4af37;
+    }
+
+    #toast {
+      position: fixed;
+      top: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #333;
+      padding: 10px 20px;
+      border-radius: 6px;
+      display: none;
+    }
+    #toast.show {
+      display: block;
+    }
+
+    .neo-icon {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      border: 2px solid #d4af37;
+      background: #14141c;
+      display: inline-block;
+      margin-left: 8px;
+      position: relative;
+    }
+    .neo-icon::after {
+      content: '';
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: #d4af37;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    button.buy {
+      background: #0f0;
+      color: #000;
+    }
+  
     /* Token dorado */
     .token {
       width: 60px;
@@ -155,76 +218,59 @@
 
   <div class="container">
     <div class="token"></div>
-    <h2>Accede a tu cuenta</h2>
+    <h2 id="title">Accede a tu cuenta</h2>
     <div class="tabs">
       <button id="tab-register" class="active">Registro</button>
       <button id="tab-login">Ingreso</button>
     </div>
 
     <form id="register-form" class="active">
-      <input type="text" placeholder="Nombre" required>
-      <input type="email" placeholder="Correo" required>
-      <input type="password" placeholder="Contraseña" required>
+      <input id="reg-first" type="text" placeholder="Nombre" required>
+      <input id="reg-last" type="text" placeholder="Apellidos" required>
+      <select id="reg-gender" required>
+        <option value="" disabled selected>Sexo</option>
+        <option value="hombre">Hombre</option>
+        <option value="mujer">Mujer</option>
+      </select>
+      <input id="reg-email" type="email" placeholder="Correo" required>
+      <div class="password-wrapper">
+        <input id="reg-password" type="password" placeholder="Contraseña" required>
+        <span class="toggle-password" data-target="reg-password">
+          <svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+        </span>
+      </div>
+      <div class="password-wrapper">
+        <input id="reg-password2" type="password" placeholder="Confirmar Contraseña" required>
+        <span class="toggle-password" data-target="reg-password2">
+          <svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+        </span>
+      </div>
       <button class="submit" type="submit">Crear Cuenta</button>
     </form>
 
     <form id="login-form">
-      <input type="email" placeholder="Correo" required>
-      <input type="password" placeholder="Contraseña" required>
+      <input id="login-email" type="email" placeholder="Correo" required>
+      <div class="password-wrapper">
+        <input id="login-password" type="password" placeholder="Contraseña" required>
+        <span class="toggle-password" data-target="login-password">
+          <svg viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+        </span>
+      </div>
       <button class="submit" type="submit">Ingresar</button>
     </form>
 
     <div id="currency-section" style="display:none; margin-top:20px;">
+      <div id="balance"><span id="neo-balance">0 NEO</span><div class="neo-icon"></div></div>
       <select id="currency-select"></select>
+      <span id="currency-display" style="display:none;"></span>
+      <input type="number" id="amount" placeholder="Cantidad en USD">
+      <button id="buy-btn" class="buy" type="button">Comprar</button>
+      <div id="rate">1 USD = 4 NEO</div>
     </div>
   </div>
 
-  <script>
-    const tabRegister = document.getElementById("tab-register");
-    const tabLogin = document.getElementById("tab-login");
-    const registerForm = document.getElementById("register-form");
-    const loginForm = document.getElementById("login-form");
-    const currencySection = document.getElementById("currency-section");
-    const currencySelect = document.getElementById("currency-select");
+  <div id="toast"></div>
 
-    tabRegister.addEventListener("click", () => {
-      tabRegister.classList.add("active");
-      tabLogin.classList.remove("active");
-      registerForm.classList.add("active");
-      loginForm.classList.remove("active");
-    });
-
-    tabLogin.addEventListener("click", () => {
-      tabLogin.classList.add("active");
-      tabRegister.classList.remove("active");
-      loginForm.classList.add("active");
-      registerForm.classList.remove("active");
-    });
-
-    const displayNames = new Intl.DisplayNames(['es'], { type: 'currency' });
-    Intl.supportedValuesOf('currency').forEach(code => {
-      const option = document.createElement('option');
-      option.value = code;
-      option.textContent = `${code} - ${displayNames.of(code)}`;
-      currencySelect.appendChild(option);
-    });
-
-    function showCurrency() {
-      registerForm.style.display = "none";
-      loginForm.style.display = "none";
-      document.querySelector(".tabs").style.display = "none";
-      currencySection.style.display = "block";
-    }
-
-    registerForm.addEventListener("submit", e => {
-      e.preventDefault();
-      showCurrency();
-    });
-
-    loginForm.addEventListener("submit", e => {
-      e.preventDefault();
-      showCurrency();
-    });
-  </script>
+  <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remember user's chosen currency and display it with balance
- hide currency selector once set and localize placeholders and rate
- replace password toggle emoji with minimalist SVG icons
- drop placeholder email verification and log new accounts in immediately

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b553168eac832087347b89ab886854