### PR TITLE
feat: adjust password visibility icon styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -109,6 +109,35 @@
       background: #0f0f1a;
       color: #fff;
     }
+
+    /* Password field with toggle icon */
+    .password-field {
+      position: relative;
+    }
+    .password-field input {
+      width: 100%;
+      padding-right: 40px;
+    }
+    .toggle-password {
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      cursor: pointer;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .toggle-password .eye-closed {
+      display: none;
+    }
+    .password-field.show .eye-open {
+      display: none;
+    }
+    .password-field.show .eye-closed {
+      display: block;
+    }
     button.submit {
       background: #d4af37;
       border: none;
@@ -164,13 +193,35 @@
     <form id="register-form" class="active">
       <input type="text" placeholder="Nombre" required>
       <input type="email" placeholder="Correo" required>
-      <input type="password" placeholder="Contraseña" required>
+      <div class="password-field">
+        <input type="password" placeholder="Contraseña" required>
+        <span class="toggle-password">
+          <svg class="eye-open" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="24" height="24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <svg class="eye-closed" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="24" height="24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.451 10.451 0 001.458 12C2.732 16.057 6.523 19 11 19c1.989 0 3.876-.561 5.456-1.523M9.88 9.88a3 3 0 104.24 4.24m-4.24-4.24L3 3m11 11l4.743 4.743M17.657 6.343A10.45 10.45 0 0120.542 12a10.451 10.451 0 01-1.664 2.769" />
+          </svg>
+        </span>
+      </div>
       <button class="submit" type="submit">Crear Cuenta</button>
     </form>
 
     <form id="login-form">
       <input type="email" placeholder="Correo" required>
-      <input type="password" placeholder="Contraseña" required>
+      <div class="password-field">
+        <input type="password" placeholder="Contraseña" required>
+        <span class="toggle-password">
+          <svg class="eye-open" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="24" height="24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <svg class="eye-closed" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="24" height="24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.451 10.451 0 001.458 12C2.732 16.057 6.523 19 11 19c1.989 0 3.876-.561 5.456-1.523M9.88 9.88a3 3 0 104.24 4.24m-4.24-4.24L3 3m11 11l4.743 4.743M17.657 6.343A10.45 10.45 0 0120.542 12a10.451 10.451 0 01-1.664 2.769" />
+          </svg>
+        </span>
+      </div>
       <button class="submit" type="submit">Ingresar</button>
     </form>
 
@@ -224,6 +275,16 @@
     loginForm.addEventListener("submit", e => {
       e.preventDefault();
       showCurrency();
+    });
+
+    // Toggle password visibility
+    document.querySelectorAll('.password-field').forEach(field => {
+      const input = field.querySelector('input');
+      const toggle = field.querySelector('.toggle-password');
+      toggle.addEventListener('click', () => {
+        const show = field.classList.toggle('show');
+        input.type = show ? 'text' : 'password';
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add toggleable eye icons next to password fields
- style password visibility icons white and align closer to inputs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b57023f3088320a7d590a0ae40f6d7