### PR TITLE
feat: add user transfers and adjust header layout

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,9 +1,42 @@
-// UI logic for tabs (Registro / Ingreso)
 (function () {
   const tabRegister = document.getElementById('tab-register');
   const tabLogin = document.getElementById('tab-login');
   const registerForm = document.getElementById('register-form');
   const loginForm = document.getElementById('login-form');
+  const currencySection = document.getElementById('currency-section');
+  const currencySelect = document.getElementById('currency-select');
+  const amountInput = document.getElementById('amount');
+  const buyBtn = document.getElementById('buy-btn');
+  const title = document.getElementById('title');
+  const toast = document.getElementById('toast');
+  const neoBalance = document.getElementById('neo-balance');
+  const currencyDisplay = document.getElementById('currency-display');
+  const rateDiv = document.getElementById('rate');
+  const settingsBtn = document.getElementById('settings-btn');
+  const settingsContainer = document.getElementById('settings-container');
+  const settingsModal = document.getElementById('settings-modal');
+  const settingsCurrency = document.getElementById('settings-currency');
+  const closeSettings = document.getElementById('close-settings');
+  const transferBtn = document.getElementById('transfer-btn');
+  const transferModal = document.getElementById('transfer-modal');
+  const transferSend = document.getElementById('transfer-send');
+  const transferClose = document.getElementById('transfer-close');
+  const userCodeSpan = document.getElementById('user-code');
+
+  const users = JSON.parse(localStorage.getItem('users') || '[]');
+  let currentUser = null;
+
+  userCodeSpan.style.display = 'none';
+
+  function saveUsers() {
+    localStorage.setItem('users', JSON.stringify(users));
+  }
+
+  function showToast(msg) {
+    toast.textContent = msg;
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 3000);
+  }
 
   function activate(which) {
     const isRegister = which === 'register';
@@ -15,7 +48,199 @@
 
   tabRegister?.addEventListener('click', () => activate('register'));
   tabLogin?.addEventListener('click', () => activate('login'));
-
-  // default
   activate('register');
+
+  document.querySelectorAll('.toggle-password').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const input = document.getElementById(btn.dataset.target);
+      const isHidden = input.type === 'password';
+      input.type = isHidden ? 'text' : 'password';
+      btn.classList.toggle('open', isHidden);
+    });
+  });
+
+  const displayNames = new Intl.DisplayNames(['es'], { type: 'currency' });
+  Intl.supportedValuesOf('currency').forEach(code => {
+    const text = `${code} - ${displayNames.of(code)}`;
+    const option1 = document.createElement('option');
+    option1.value = code;
+    option1.textContent = text;
+    currencySelect.appendChild(option1);
+    const option2 = document.createElement('option');
+    option2.value = code;
+    option2.textContent = text;
+    settingsCurrency.appendChild(option2);
+  });
+  currencySelect.value = 'USD';
+  settingsCurrency.value = 'USD';
+
+  function showCurrency() {
+    registerForm.style.display = 'none';
+    loginForm.style.display = 'none';
+    document.querySelector('.tabs').style.display = 'none';
+    currencySection.style.display = 'block';
+  }
+
+  function updateBalance() {
+    neoBalance.textContent = `${currentUser.balance} NEO`;
+  }
+
+  function updateCurrencyUI() {
+    const cur = currentUser?.currency || currencySelect.value || 'USD';
+    amountInput.placeholder = `Cantidad en ${cur}`;
+    rateDiv.textContent = `1 ${cur} = 4 NEO`;
+    currencyDisplay.textContent = `Divisa: ${cur}`;
+    const hasCurrency = !!currentUser?.currency;
+    currencyDisplay.style.display = hasCurrency ? 'block' : 'none';
+    currencySelect.style.display = hasCurrency ? 'none' : 'block';
+    if (hasCurrency) {
+      currencySelect.value = cur;
+    }
+    settingsCurrency.value = cur;
+  }
+
+  function generateCode() {
+    let code;
+    do {
+      code = Math.random().toString(36).slice(2, 8);
+    } while (users.some(u => u.code === code));
+    return code;
+  }
+
+  function ensureCode(user) {
+    if (!user.code) {
+      user.code = generateCode();
+      saveUsers();
+    }
+  }
+
+  function loginUser(user) {
+    ensureCode(user);
+    currentUser = user;
+    const greet = user.gender === 'mujer' ? 'bienvenida' : 'bienvenido';
+    title.textContent = `${user.first} ${greet} a NEÓN-R`;
+    title.style.color = '#87ceeb';
+    userCodeSpan.style.display = 'inline';
+    userCodeSpan.textContent = user.code;
+    settingsContainer.style.display = 'flex';
+    showCurrency();
+    updateBalance();
+    updateCurrencyUI();
+  }
+
+  registerForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const first = document.getElementById('reg-first').value.trim();
+    const last = document.getElementById('reg-last').value.trim();
+    const gender = document.getElementById('reg-gender').value;
+    const email = document.getElementById('reg-email').value.trim().toLowerCase();
+    const pass = document.getElementById('reg-password').value;
+    const pass2 = document.getElementById('reg-password2').value;
+
+    if (users.some(u => u.first.toLowerCase() === first.toLowerCase())) {
+      showToast('este nombre ya está registrado');
+      return;
+    }
+    if (users.some(u => u.email === email)) {
+      showToast('este correo ya existe');
+      return;
+    }
+    if (!/^(?=.*[A-Za-z])(?=.*\d).{8,}$/.test(pass)) {
+      showToast('la contraseña debe tener 8 letras y un número');
+      return;
+    }
+    if (pass !== pass2) {
+      showToast('las contraseñas no coinciden');
+      return;
+    }
+
+    const user = { first, last, gender, email, pass, balance: 0, currency: null, code: generateCode() };
+    users.push(user);
+    saveUsers();
+    loginUser(user);
+  });
+
+  loginForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const email = document.getElementById('login-email').value.trim().toLowerCase();
+    const pass = document.getElementById('login-password').value;
+    const user = users.find(u => u.email === email);
+    if (!user) {
+      showToast('este correo no existe');
+      return;
+    }
+    if (user.pass !== pass) {
+      showToast('contraseña incorrecta');
+      return;
+    }
+    loginUser(user);
+  });
+
+  currencySelect.addEventListener('change', () => {
+    if (!currentUser) return;
+    currentUser.currency = currencySelect.value;
+    saveUsers();
+    updateCurrencyUI();
+  });
+
+  settingsBtn.addEventListener('click', () => {
+    settingsModal.style.display = 'flex';
+  });
+
+  closeSettings.addEventListener('click', () => {
+    settingsModal.style.display = 'none';
+  });
+
+  settingsCurrency.addEventListener('change', () => {
+    if (!currentUser) return;
+    currentUser.currency = settingsCurrency.value;
+    saveUsers();
+    updateCurrencyUI();
+  });
+
+  buyBtn.addEventListener('click', () => {
+    const amount = parseFloat(amountInput.value);
+    if (isNaN(amount) || amount <= 0) {
+      showToast('ingresa una cantidad válida');
+      return;
+    }
+    const neo = Math.round(amount * 4);
+    currentUser.balance += neo;
+    saveUsers();
+    updateBalance();
+    showToast(`compraste ${neo} NEO`);
+  });
+
+  transferBtn.addEventListener('click', () => {
+    transferModal.style.display = 'flex';
+  });
+
+  transferClose.addEventListener('click', () => {
+    transferModal.style.display = 'none';
+  });
+
+  transferSend.addEventListener('click', () => {
+    const code = document.getElementById('transfer-code').value.trim();
+    const amount = parseInt(document.getElementById('transfer-amount').value, 10);
+    if (isNaN(amount) || amount <= 0) {
+      showToast('ingresa una cantidad válida');
+      return;
+    }
+    if (amount > currentUser.balance) {
+      showToast('saldo insuficiente');
+      return;
+    }
+    const recipient = users.find(u => u.code === code);
+    if (!recipient) {
+      showToast('usuario no encontrado');
+      return;
+    }
+    currentUser.balance -= amount;
+    recipient.balance += amount;
+    saveUsers();
+    updateBalance();
+    showToast(`enviaste ${amount} NEO`);
+    transferModal.style.display = 'none';
+  });
 })();
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,8 +49,17 @@
       background-color: #111122;
       border-bottom: 1px solid #333;
     }
+    header .left,
+    header .right {
+      display: flex;
+      align-items: center;
+      gap: 15px;
+    }
     header img {
       height: 40px;
+    }
+    .user-code {
+      font-weight: bold;
     }
     .status {
       background: #0f0;
@@ -59,6 +68,47 @@
       padding: 4px 10px;
       border-radius: 6px;
       font-size: 0.9em;
+    }
+
+    .settings-container {
+      display: flex;
+      justify-content: flex-end;
+      padding: 10px 30px 0;
+    }
+
+    .settings {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: #fff;
+      position: relative;
+      padding: 0;
+    }
+    .settings svg {
+      width: 32px;
+      height: 32px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    .settings-label {
+      position: absolute;
+      top: 50%;
+      right: 100%;
+      transform: translateY(-50%);
+      background: #111122;
+      padding: 4px 8px;
+      border-radius: 4px;
+      white-space: nowrap;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s;
+      font-size: 0.85em;
+    }
+    .settings:hover .settings-label {
+      opacity: 1;
     }
 
     .container {
@@ -119,6 +169,128 @@
       margin-top: 10px;
     }
 
+    .password-wrapper {
+      position: relative;
+    }
+    .toggle-password {
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      cursor: pointer;
+    }
+    .password-wrapper input {
+      padding-right: 40px;
+    }
+    .toggle-password .eye {
+      width: 20px;
+      height: 20px;
+      stroke: #fff;
+      fill: none;
+    }
+    .toggle-password .eye circle {
+      fill: #fff;
+    }
+    .toggle-password .eye-open {
+      display: none;
+    }
+    .toggle-password.open .eye-open {
+      display: block;
+    }
+    .toggle-password.open .eye-closed {
+      display: none;
+    }
+
+    #toast {
+      position: fixed;
+      top: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #333;
+      padding: 10px 20px;
+      border-radius: 6px;
+      display: none;
+    }
+    #toast.show {
+      display: block;
+    }
+
+    .neo-icon {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      border: 2px solid #d4af37;
+      background: #14141c;
+      display: inline-block;
+      margin-left: 8px;
+      position: relative;
+    }
+    .neo-icon::after {
+      content: '';
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: #d4af37;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    button.buy {
+      background: #0f0;
+      color: #000;
+    }
+
+
+    button.transfer {
+      background: #333;
+      color: #fff;
+      border: none;
+      padding: 8px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      margin-left: 10px;
+    }
+
+    #settings-modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.8);
+      display: none;
+      justify-content: center;
+      align-items: center;
+    }
+
+    #settings-modal .content {
+      background: #14141c;
+      padding: 20px;
+      border-radius: 8px;
+      text-align: center;
+    }
+
+    #transfer-modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.8);
+      display: none;
+      justify-content: center;
+      align-items: center;
+    }
+
+    #transfer-modal .content {
+      background: #14141c;
+      padding: 20px;
+      border-radius: 8px;
+      text-align: center;
+    }
+  
     /* Token dorado */
     .token {
       width: 60px;
@@ -149,82 +321,107 @@
   </div>
 
   <header>
-    <img src="logo.png" alt="Logo">
-    <div class="status">Sistema en línea</div>
+    <div class="left">
+      <img src="logo.png" alt="Logo">
+      <span id="user-code" class="user-code"></span>
+    </div>
+    <div class="right">
+      <div class="status">Sistema en línea</div>
+    </div>
   </header>
+
+  <div id="settings-container" class="settings-container" style="display:none;">
+  <button id="settings-btn" class="settings" type="button" aria-label="Configuración">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 0 0 2.572-1.065z"/>
+      <path d="M10 9h4a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1z"/>
+    </svg>
+    <span class="settings-label">Configuración</span>
+  </button>
+  </div>
 
   <div class="container">
     <div class="token"></div>
-    <h2>Accede a tu cuenta</h2>
+    <h2 id="title">Accede a tu cuenta</h2>
     <div class="tabs">
       <button id="tab-register" class="active">Registro</button>
       <button id="tab-login">Ingreso</button>
     </div>
 
     <form id="register-form" class="active">
-      <input type="text" placeholder="Nombre" required>
-      <input type="email" placeholder="Correo" required>
-      <input type="password" placeholder="Contraseña" required>
+      <input id="reg-first" type="text" placeholder="Nombre" required>
+      <input id="reg-last" type="text" placeholder="Apellidos" required>
+      <select id="reg-gender" required>
+        <option value="" disabled selected>Sexo</option>
+        <option value="hombre">Hombre</option>
+        <option value="mujer">Mujer</option>
+      </select>
+      <input id="reg-email" type="email" placeholder="Correo" required>
+      <div class="password-wrapper">
+        <input id="reg-password" type="password" placeholder="Contraseña" required>
+        <span class="toggle-password" data-target="reg-password">
+          <svg class="eye eye-closed" viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+          <svg class="eye eye-open" viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+        </span>
+      </div>
+      <div class="password-wrapper">
+        <input id="reg-password2" type="password" placeholder="Confirmar Contraseña" required>
+        <span class="toggle-password" data-target="reg-password2">
+          <svg class="eye eye-closed" viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+          <svg class="eye eye-open" viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+        </span>
+      </div>
       <button class="submit" type="submit">Crear Cuenta</button>
     </form>
 
     <form id="login-form">
-      <input type="email" placeholder="Correo" required>
-      <input type="password" placeholder="Contraseña" required>
+      <input id="login-email" type="email" placeholder="Correo" required>
+      <div class="password-wrapper">
+        <input id="login-password" type="password" placeholder="Contraseña" required>
+        <span class="toggle-password" data-target="login-password">
+          <svg class="eye eye-closed" viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+          <svg class="eye eye-open" viewBox="0 0 24 24"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+        </span>
+      </div>
       <button class="submit" type="submit">Ingresar</button>
     </form>
 
     <div id="currency-section" style="display:none; margin-top:20px;">
+      <div id="balance"><span id="neo-balance">0 NEO</span><div class="neo-icon"></div></div>
       <select id="currency-select"></select>
+      <span id="currency-display" style="display:none;"></span>
+      <input type="number" id="amount" placeholder="Cantidad en USD" min="1">
+      <button id="buy-btn" class="buy" type="button">Comprar</button>
+      <button id="transfer-btn" class="transfer" type="button">Transferir</button>
+      <div id="rate">1 USD = 4 NEO</div>
     </div>
   </div>
 
-  <script>
-    const tabRegister = document.getElementById("tab-register");
-    const tabLogin = document.getElementById("tab-login");
-    const registerForm = document.getElementById("register-form");
-    const loginForm = document.getElementById("login-form");
-    const currencySection = document.getElementById("currency-section");
-    const currencySelect = document.getElementById("currency-select");
+  <div id="toast"></div>
 
-    tabRegister.addEventListener("click", () => {
-      tabRegister.classList.add("active");
-      tabLogin.classList.remove("active");
-      registerForm.classList.add("active");
-      loginForm.classList.remove("active");
-    });
+  <div id="settings-modal">
+    <div class="content">
+      <h3>Configuración</h3>
+      <label for="settings-currency">Divisa</label>
+      <select id="settings-currency"></select>
+      <div style="margin-top:15px;">
+        <button id="close-settings" type="button">Cerrar</button>
+      </div>
+    </div>
+  </div>
 
-    tabLogin.addEventListener("click", () => {
-      tabLogin.classList.add("active");
-      tabRegister.classList.remove("active");
-      loginForm.classList.add("active");
-      registerForm.classList.remove("active");
-    });
+  <div id="transfer-modal">
+    <div class="content">
+      <h3>Enviar NEO</h3>
+      <input id="transfer-code" type="text" placeholder="Código de usuario">
+      <input id="transfer-amount" type="number" placeholder="Cantidad de NEO" min="1">
+      <div style="margin-top:15px;">
+        <button id="transfer-send" type="button">Enviar</button>
+        <button id="transfer-close" type="button">Cerrar</button>
+      </div>
+    </div>
+  </div>
 
-    const displayNames = new Intl.DisplayNames(['es'], { type: 'currency' });
-    Intl.supportedValuesOf('currency').forEach(code => {
-      const option = document.createElement('option');
-      option.value = code;
-      option.textContent = `${code} - ${displayNames.of(code)}`;
-      currencySelect.appendChild(option);
-    });
-
-    function showCurrency() {
-      registerForm.style.display = "none";
-      loginForm.style.display = "none";
-      document.querySelector(".tabs").style.display = "none";
-      currencySection.style.display = "block";
-    }
-
-    registerForm.addEventListener("submit", e => {
-      e.preventDefault();
-      showCurrency();
-    });
-
-    loginForm.addEventListener("submit", e => {
-      e.preventDefault();
-      showCurrency();
-    });
-  </script>
+  <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move user transfer code to follow the logo in the header
- drop settings button from header and show it below top bar
- prevent negative purchases by enforcing minimum amount
- show configuration label only on hover over gear icon
- replace malformed settings cog with centered 6-tooth icon and sky-blue welcome message honoring user gender
- redraw settings button with crisp gear svg to avoid deformation
- reveal settings button only after successful login for a cleaner sign-in screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b553168eac832087347b89ab886854