### PR TITLE
Add simulator purchase button with balance deduction

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7,6 +7,7 @@
   const currencySelect = document.getElementById('currency-select');
   const amountInput = document.getElementById('amount');
   const buyBtn = document.getElementById('buy-btn');
+  const simulatorBtn = document.getElementById('simulator-btn');
   const title = document.getElementById('title');
   const toast = document.getElementById('toast');
   const neoBalance = document.getElementById('neo-balance');
@@ -243,6 +244,19 @@
 
   transferClose.addEventListener('click', () => {
     transferModal.style.display = 'none';
+  });
+
+  simulatorBtn.addEventListener('click', () => {
+    if (!currentUser) return;
+    if (currentUser.balance < 3) {
+      showToast('necesitas al menos 3 NEO para acceder al simulador');
+      return;
+    }
+    currentUser.balance -= 3;
+    saveUsers();
+    updateBalance();
+    showToast('se descontaron 3 NEO para acceder al simulador');
+    window.open('https://resplendent-encouragement-production.up.railway.app/', '_blank');
   });
 
   transferSend.addEventListener('click', () => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9,6 +9,7 @@
   const buyBtn = document.getElementById('buy-btn');
   const simulatorBtn = document.getElementById('simulator-btn');
   const videoGameBtn = document.getElementById('video-game-btn');
+  const youtubeBtn = document.getElementById('youtube-btn');
   const title = document.getElementById('title');
   const toast = document.getElementById('toast');
   const neoBalance = document.getElementById('neo-balance');
@@ -271,6 +272,11 @@
     updateBalance();
     showToast('se descontaron 6 NEO para comprar el video juego');
     window.open('https://itanimulli-production.up.railway.app/', '_blank');
+  });
+
+  youtubeBtn.addEventListener('click', () => {
+    if (!currentUser) return;
+    window.open('https://www.youtube.com/@Solix-19', '_blank');
   });
 
   transferSend.addEventListener('click', () => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8,6 +8,7 @@
   const amountInput = document.getElementById('amount');
   const buyBtn = document.getElementById('buy-btn');
   const simulatorBtn = document.getElementById('simulator-btn');
+  const videoGameBtn = document.getElementById('video-game-btn');
   const title = document.getElementById('title');
   const toast = document.getElementById('toast');
   const neoBalance = document.getElementById('neo-balance');
@@ -257,6 +258,19 @@
     updateBalance();
     showToast('se descontaron 3 NEO para acceder al simulador');
     window.open('https://resplendent-encouragement-production.up.railway.app/', '_blank');
+  });
+
+  videoGameBtn.addEventListener('click', () => {
+    if (!currentUser) return;
+    if (currentUser.balance < 6) {
+      showToast('necesitas al menos 6 NEO para comprar el video juego');
+      return;
+    }
+    currentUser.balance -= 6;
+    saveUsers();
+    updateBalance();
+    showToast('se descontaron 6 NEO para comprar el video juego');
+    window.open('https://itanimulli-production.up.railway.app/', '_blank');
   });
 
   transferSend.addEventListener('click', () => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -250,14 +250,14 @@
 
   simulatorBtn.addEventListener('click', () => {
     if (!currentUser) return;
-    if (currentUser.balance < 3) {
-      showToast('necesitas al menos 3 NEO para acceder al simulador');
+    if (currentUser.balance < 6) {
+      showToast('necesitas al menos 6 NEO para rentar el simulador');
       return;
     }
-    currentUser.balance -= 3;
+    currentUser.balance -= 6;
     saveUsers();
     updateBalance();
-    showToast('se descontaron 3 NEO para acceder al simulador');
+    showToast('se descontaron 6 NEO para rentar el simulador');
     window.open('https://resplendent-encouragement-production.up.railway.app/', '_blank');
   });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -266,6 +266,14 @@
       background: #1870cc;
     }
 
+    .simulator-access.youtube-link {
+      background: #d32f2f;
+    }
+
+    .simulator-access.youtube-link:hover {
+      background: #b71c1c;
+    }
+
 
     button.transfer {
       background: #333;
@@ -358,6 +366,7 @@
     <div class="settings-actions">
       <button id="simulator-btn" class="simulator-access" type="button">COMPRAR simulador</button>
       <button id="video-game-btn" class="simulator-access" type="button">COMPRAR VIDEO JUEGO</button>
+      <button id="youtube-btn" class="simulator-access youtube-link" type="button">YOUTUBE</button>
     </div>
     <button id="settings-btn" class="settings" type="button" aria-label="Configuración">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -242,6 +242,22 @@
       color: #000;
     }
 
+    .simulator-access {
+      background: #1e90ff;
+      color: #fff;
+      border: none;
+      padding: 10px 18px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-weight: bold;
+      margin-bottom: 15px;
+      transition: background 0.2s ease;
+    }
+
+    .simulator-access:hover {
+      background: #1870cc;
+    }
+
 
     button.transfer {
       background: #333;
@@ -387,6 +403,7 @@
     </form>
 
     <div id="currency-section" style="display:none; margin-top:20px;">
+      <button id="simulator-btn" class="simulator-access" type="button">COMPRAR simulador</button>
       <div id="balance"><span id="neo-balance">0 NEO</span><div class="neo-icon"></div></div>
       <select id="currency-select"></select>
       <span id="currency-display" style="display:none;"></span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -72,8 +72,9 @@
 
     .settings-container {
       display: flex;
-      justify-content: flex-end;
+      align-items: center;
       padding: 10px 30px 0;
+      gap: 12px;
     }
 
     .settings {
@@ -83,6 +84,7 @@
       color: #fff;
       position: relative;
       padding: 0;
+      margin-left: auto;
     }
     .settings svg {
       width: 32px;
@@ -250,7 +252,7 @@
       border-radius: 6px;
       cursor: pointer;
       font-weight: bold;
-      margin-bottom: 15px;
+      margin: 0;
       transition: background 0.2s ease;
     }
 
@@ -347,13 +349,14 @@
   </header>
 
   <div id="settings-container" class="settings-container" style="display:none;">
-  <button id="settings-btn" class="settings" type="button" aria-label="Configuración">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 0 0 2.572-1.065z"/>
-      <path d="M10 9h4a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1z"/>
-    </svg>
-    <span class="settings-label">Configuración</span>
-  </button>
+    <button id="simulator-btn" class="simulator-access" type="button">COMPRAR simulador</button>
+    <button id="settings-btn" class="settings" type="button" aria-label="Configuración">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 0 0 2.572-1.065z"/>
+        <path d="M10 9h4a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1z"/>
+      </svg>
+      <span class="settings-label">Configuración</span>
+    </button>
   </div>
 
   <div class="container">
@@ -403,7 +406,6 @@
     </form>
 
     <div id="currency-section" style="display:none; margin-top:20px;">
-      <button id="simulator-btn" class="simulator-access" type="button">COMPRAR simulador</button>
       <div id="balance"><span id="neo-balance">0 NEO</span><div class="neo-icon"></div></div>
       <select id="currency-select"></select>
       <span id="currency-display" style="display:none;"></span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -72,9 +72,15 @@
 
     .settings-container {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       padding: 10px 30px 0;
       gap: 12px;
+    }
+
+    .settings-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
     }
 
     .settings {
@@ -349,7 +355,10 @@
   </header>
 
   <div id="settings-container" class="settings-container" style="display:none;">
-    <button id="simulator-btn" class="simulator-access" type="button">COMPRAR simulador</button>
+    <div class="settings-actions">
+      <button id="simulator-btn" class="simulator-access" type="button">COMPRAR simulador</button>
+      <button id="video-game-btn" class="simulator-access" type="button">COMPRAR VIDEO JUEGO</button>
+    </div>
     <button id="settings-btn" class="settings" type="button" aria-label="Configuración">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 0 0 2.572-1.065z"/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -364,7 +364,7 @@
 
   <div id="settings-container" class="settings-container" style="display:none;">
     <div class="settings-actions">
-      <button id="simulator-btn" class="simulator-access" type="button">COMPRAR simulador</button>
+      <button id="simulator-btn" class="simulator-access" type="button">RENTAR SIMULADOR</button>
       <button id="video-game-btn" class="simulator-access" type="button">COMPRAR VIDEO JUEGO</button>
       <button id="youtube-btn" class="simulator-access youtube-link" type="button">YOUTUBE</button>
     </div>


### PR DESCRIPTION
## Summary
- add a blue "COMPRAR simulador" button to the currency panel so the simulator is visible after logging in
- style the new button to match the interface and open the external simulator while deducting 3 NEO from the balance

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce4c3432b8832091b10fb0ca423445