### PR TITLE
Align CTA panel with header controls

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -18,6 +18,7 @@
   const rateDiv = document.getElementById('rate');
   const settingsContainer = document.getElementById('settings-container');
   const settingsBtn = document.getElementById('settings-btn');
+  const participateBtn = document.getElementById('participate-btn');
   const settingsModal = document.getElementById('settings-modal');
   const settingsCurrency = document.getElementById('settings-currency');
   const closeSettings = document.getElementById('close-settings');
@@ -40,6 +41,9 @@
   settingsContainer.style.display = 'none';
   if (settingsBtn) {
     settingsBtn.style.display = 'none';
+  }
+  if (participateBtn) {
+    participateBtn.style.display = 'none';
   }
   if (neoOfferWrapper) {
     neoOfferWrapper.style.display = 'none';
@@ -161,6 +165,9 @@
     if (settingsBtn) {
       settingsBtn.style.display = 'flex';
     }
+    if (participateBtn) {
+      participateBtn.style.display = 'flex';
+    }
     if (neoOfferWrapper) {
       neoOfferWrapper.style.display = 'block';
     }
@@ -226,6 +233,11 @@
 
   settingsBtn.addEventListener('click', () => {
     settingsModal.style.display = 'flex';
+  });
+
+  participateBtn?.addEventListener('click', () => {
+    if (!currentUser) return;
+    window.open('https://www.youtube.com/shorts/R-XSFF1rVFQ', '_blank');
   });
 
   closeSettings.addEventListener('click', () => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -17,6 +17,7 @@
   const currencyDisplay = document.getElementById('currency-display');
   const rateDiv = document.getElementById('rate');
   const settingsContainer = document.getElementById('settings-container');
+  const fabStack = document.getElementById('fab-stack');
   const settingsBtn = document.getElementById('settings-btn');
   const participateBtn = document.getElementById('participate-btn');
   const settingsModal = document.getElementById('settings-modal');
@@ -39,6 +40,9 @@
 
   userCodeSpan.style.display = 'none';
   settingsContainer.style.display = 'none';
+  if (fabStack) {
+    fabStack.style.display = 'none';
+  }
   if (settingsBtn) {
     settingsBtn.style.display = 'none';
   }
@@ -170,6 +174,9 @@
     }
     if (neoOfferWrapper) {
       neoOfferWrapper.style.display = 'block';
+    }
+    if (fabStack) {
+      fabStack.style.display = 'block';
     }
     showCurrency();
     updateBalance();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -27,11 +27,14 @@
   const transferSend = document.getElementById('transfer-send');
   const transferClose = document.getElementById('transfer-close');
   const userCodeSpan = document.getElementById('user-code');
+  const body = document.body;
 
   const users = JSON.parse(localStorage.getItem('users') || '[]');
   let currentUser = null;
   let rates = {};
   const MXN_PER_NEO = 7;
+
+  body.classList.remove('cta-aligned');
 
   userCodeSpan.style.display = 'none';
   settingsContainer.style.display = 'none';
@@ -148,6 +151,7 @@
   function loginUser(user) {
     ensureCode(user);
     currentUser = user;
+    body.classList.add('cta-aligned');
     const greet = user.gender === 'mujer' ? 'bienvenida' : 'bienvenido';
     title.textContent = `${user.first} ${greet} a NEÓN-R`;
     title.style.color = '#87ceeb';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -206,6 +206,40 @@
       box-shadow: 0 0 16px rgba(255, 153, 0, 0.6), inset 0 0 8px rgba(255, 255, 255, 0.4);
     }
 
+    #cta-panel {
+      margin-top: -50px;
+    }
+
+    #cta-button {
+      margin-top: -22px;
+    }
+
+    @media (min-width: 768px) {
+      #cta-panel {
+        margin-top: -168px;
+      }
+
+      #cta-button {
+        margin-top: -44px;
+      }
+    }
+
+    @media (min-width: 1280px) {
+      #cta-panel {
+        margin-top: -168px;
+      }
+
+      #cta-button {
+        margin-top: -46px;
+      }
+    }
+
+    @media (max-width: 767px) {
+      #cta-panel {
+        padding-top: 50px;
+      }
+    }
+
     .container {
       max-width: 600px;
       margin: 40px auto;
@@ -480,7 +514,7 @@
     </button>
   </div>
 
-  <div class="container">
+  <div id="cta-panel" class="container">
     <div class="token"></div>
     <h2 id="title">Accede a tu cuenta</h2>
     <div class="tabs">
@@ -538,7 +572,7 @@
   </div>
 
   <div id="neo-offer-wrapper" class="neo-offer-wrapper" style="display:none;">
-    <button id="neo-offer-btn" class="neo-offer-btn" type="button">NEOS GRATIS POR TIEMPO LIMITADO Y EXCLUSIVO</button>
+    <button id="cta-button" class="neo-offer-btn" type="button">NEOS GRATIS POR TIEMPO LIMITADO Y EXCLUSIVO</button>
   </div>
 
   <div id="toast"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -206,36 +206,36 @@
       box-shadow: 0 0 16px rgba(255, 153, 0, 0.6), inset 0 0 8px rgba(255, 255, 255, 0.4);
     }
 
-    #cta-panel {
+    body.cta-aligned #cta-panel {
       margin-top: -50px;
     }
 
-    #cta-button {
+    body.cta-aligned #cta-button {
       margin-top: -22px;
     }
 
     @media (min-width: 768px) {
-      #cta-panel {
+      body.cta-aligned #cta-panel {
         margin-top: -168px;
       }
 
-      #cta-button {
+      body.cta-aligned #cta-button {
         margin-top: -44px;
       }
     }
 
     @media (min-width: 1280px) {
-      #cta-panel {
+      body.cta-aligned #cta-panel {
         margin-top: -168px;
       }
 
-      #cta-button {
+      body.cta-aligned #cta-button {
         margin-top: -46px;
       }
     }
 
     @media (max-width: 767px) {
-      #cta-panel {
+      body.cta-aligned #cta-panel {
         padding-top: 50px;
       }
     }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -212,14 +212,24 @@
         width: 100%;
       }
 
-      #cta-stack {
+      body.cta-aligned #cta-stack {
         width: calc(100% - 88px);
         margin-right: auto;
       }
 
-      #cta-panel {
+      body:not(.cta-aligned) #cta-stack {
+        width: calc(100% - 44px);
+      }
+
+      body.cta-aligned #cta-panel {
         margin-left: 0;
         margin-right: 0;
+        width: 100%;
+      }
+
+      body:not(.cta-aligned) #cta-panel {
+        margin-left: auto;
+        margin-right: auto;
         width: 100%;
       }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -101,9 +101,9 @@
     }
 
     body:not(.cta-aligned) #cta-stack {
-      max-width: min(920px, calc(100% - 48px));
-      margin: 48px auto 64px;
-      gap: 28px;
+      max-width: min(736px, calc(100% - 64px));
+      margin: 40px auto 52px;
+      gap: 22px;
     }
 
     #fab-stack {
@@ -251,32 +251,32 @@
     }
 
     body:not(.cta-aligned) #cta-panel {
-      max-width: min(840px, calc(100% - 48px));
+      max-width: min(672px, calc(100% - 64px));
       width: 100%;
-      padding: clamp(36px, 6vw, 60px) clamp(28px, 7vw, 72px);
+      padding: clamp(28px, 4.8vw, 48px) clamp(22px, 5.6vw, 58px);
       margin: 0 auto;
     }
 
     @media (max-width: 768px) {
       body:not(.cta-aligned) #cta-stack {
-        max-width: calc(100% - 32px);
-        margin: 36px auto 52px;
-        gap: 20px;
+        max-width: calc(100% - 40px);
+        margin: 28px auto 42px;
+        gap: 16px;
       }
 
       body:not(.cta-aligned) #cta-panel {
         max-width: 100%;
-        padding: 30px 22px;
+        padding: 24px 18px;
       }
     }
 
     @media (max-width: 480px) {
       body:not(.cta-aligned) #cta-stack {
-        margin: 28px auto 40px;
+        margin: 22px auto 32px;
       }
 
       body:not(.cta-aligned) #cta-panel {
-        padding: 26px 18px;
+        padding: 21px 14px;
       }
     }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -244,6 +244,17 @@
       box-shadow: 0 0 16px rgba(255, 153, 0, 0.6), inset 0 0 8px rgba(255, 255, 255, 0.4);
     }
 
+    body:not(.cta-aligned) #cta-panel {
+      max-width: 720px;
+      padding: 40px 48px;
+    }
+
+    @media (max-width: 768px) {
+      body:not(.cta-aligned) #cta-panel {
+        padding: 32px 24px;
+      }
+    }
+
     body.cta-aligned #cta-panel {
       margin-top: -50px;
     }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,12 +92,30 @@
       gap: 8px;
     }
 
-    .settings-tools {
-      margin-left: auto;
-      margin-right: 40px;
+    #cta-stack {
+      margin-top: 16px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 100%;
+    }
+
+    #fab-stack {
+      position: fixed;
+      inset: 0;
+      z-index: 50;
+      pointer-events: none;
+      display: none;
+    }
+
+    #fab-stack .fab-column {
+      position: absolute;
+      right: max(16px, env(safe-area-inset-right));
+      top: 120px;
       display: flex;
       flex-direction: column;
       gap: 12px;
+      pointer-events: auto;
       align-items: center;
     }
 
@@ -181,23 +199,30 @@
       }
 
       .settings-container {
-        display: grid;
-        grid-template-columns: minmax(0, 1fr) minmax(72px, auto);
-        align-items: flex-start;
-        gap: 20px;
+        display: block;
       }
 
       .settings-actions {
         width: 100%;
       }
 
-      .settings-tools {
+      #cta-stack {
+        width: calc(100% - 88px);
+        margin-right: auto;
+      }
+
+      #cta-panel {
         margin-left: 0;
         margin-right: 0;
-        align-self: center;
-        align-items: center;
-        justify-self: end;
-        gap: 16px;
+        width: 100%;
+      }
+
+      #neo-offer-wrapper {
+        margin-left: 0;
+        margin-right: 0;
+        padding-left: 0;
+        padding-right: 0;
+        width: 100%;
       }
     }
 
@@ -518,7 +543,10 @@
       <button id="youtube-btn" class="simulator-access youtube-link" type="button">YOUTUBE</button>
       <button id="tiktok-btn" class="simulator-access tiktok-link" type="button">TIK TOK</button>
     </div>
-    <div class="settings-tools">
+  </div>
+
+  <div id="fab-stack">
+    <div class="fab-column">
       <button id="settings-btn" class="settings" type="button" aria-label="Configuración" style="display:none;">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 0 0 2.572-1.065z"/>
@@ -539,10 +567,11 @@
     </div>
   </div>
 
-  <div id="cta-panel" class="container">
-    <div class="token"></div>
-    <h2 id="title">Accede a tu cuenta</h2>
-    <div class="tabs">
+  <div id="cta-stack">
+    <div id="cta-panel" class="container">
+      <div class="token"></div>
+      <h2 id="title">Accede a tu cuenta</h2>
+      <div class="tabs">
       <button id="tab-register" class="active">Registro</button>
       <button id="tab-login">Ingreso</button>
     </div>
@@ -596,8 +625,9 @@
     </div>
   </div>
 
-  <div id="neo-offer-wrapper" class="neo-offer-wrapper" style="display:none;">
-    <button id="cta-button" class="neo-offer-btn" type="button">NEOS GRATIS POR TIEMPO LIMITADO Y EXCLUSIVO</button>
+    <div id="neo-offer-wrapper" class="neo-offer-wrapper" style="display:none;">
+      <button id="cta-button" class="neo-offer-btn" type="button">NEOS GRATIS POR TIEMPO LIMITADO Y EXCLUSIVO</button>
+    </div>
   </div>
 
   <div id="toast"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -215,6 +215,7 @@
       body.cta-aligned #cta-stack {
         width: calc(100% - 88px);
         margin-right: auto;
+        transform: none;
       }
 
       body:not(.cta-aligned) #cta-stack {
@@ -279,6 +280,7 @@
         max-width: calc(100% - 44px);
         margin: 28px auto 42px;
         gap: 16px;
+        transform: translateX(-15px);
       }
 
       body:not(.cta-aligned) #cta-panel,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,10 +92,13 @@
       gap: 8px;
     }
 
-    .settings-container .settings {
+    .settings-tools {
       margin-left: auto;
       margin-right: 40px;
-      align-self: flex-start;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      align-items: center;
     }
 
     .settings {
@@ -183,8 +186,10 @@
         gap: 16px;
       }
 
-      .settings-container .settings {
+      .settings-tools {
         margin-left: 0;
+        margin-right: 0;
+        align-items: flex-start;
       }
     }
 
@@ -505,13 +510,25 @@
       <button id="youtube-btn" class="simulator-access youtube-link" type="button">YOUTUBE</button>
       <button id="tiktok-btn" class="simulator-access tiktok-link" type="button">TIK TOK</button>
     </div>
-    <button id="settings-btn" class="settings" type="button" aria-label="Configuración" style="display:none;">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 0 0 2.572-1.065z"/>
-        <path d="M10 9h4a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1z"/>
-      </svg>
-      <span class="settings-label">Configuración</span>
-    </button>
+    <div class="settings-tools">
+      <button id="settings-btn" class="settings" type="button" aria-label="Configuración" style="display:none;">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37a1.724 1.724 0 0 0 2.572-1.065z"/>
+          <path d="M10 9h4a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1z"/>
+        </svg>
+        <span class="settings-label">Configuración</span>
+      </button>
+      <button id="participate-btn" class="settings" type="button" aria-label="Participa" title="Participa" style="display:none;">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <polyline points="20 12 20 22 4 22 4 12"></polyline>
+          <rect x="2" y="7" width="20" height="5"></rect>
+          <line x1="12" y1="22" x2="12" y2="7"></line>
+          <path d="M12 7 7.5 2A2.5 2.5 0 0 0 5 7c0 2 2 2 7 2"></path>
+          <path d="M12 7 16.5 2A2.5 2.5 0 0 1 19 7c0 2-2 2-7 2"></path>
+        </svg>
+        <span class="settings-label">Participa</span>
+      </button>
+    </div>
   </div>
 
   <div id="cta-panel" class="container">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -181,15 +181,23 @@
       }
 
       .settings-container {
-        flex-direction: column;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(72px, auto);
         align-items: flex-start;
-        gap: 16px;
+        gap: 20px;
+      }
+
+      .settings-actions {
+        width: 100%;
       }
 
       .settings-tools {
         margin-left: 0;
         margin-right: 0;
-        align-items: flex-start;
+        align-self: center;
+        align-items: center;
+        justify-self: end;
+        gap: 16px;
       }
     }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -280,7 +280,7 @@
         max-width: calc(100% - 44px);
         margin: 28px auto 42px;
         gap: 16px;
-        transform: translateX(-15px);
+        transform: translateX(calc(-15px + 1mm));
       }
 
       body:not(.cta-aligned) #cta-panel,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -100,6 +100,12 @@
       width: 100%;
     }
 
+    body:not(.cta-aligned) #cta-stack {
+      max-width: min(920px, calc(100% - 48px));
+      margin: 48px auto 64px;
+      gap: 28px;
+    }
+
     #fab-stack {
       position: fixed;
       inset: 0;
@@ -245,13 +251,32 @@
     }
 
     body:not(.cta-aligned) #cta-panel {
-      max-width: 720px;
-      padding: 40px 48px;
+      max-width: min(840px, calc(100% - 48px));
+      width: 100%;
+      padding: clamp(36px, 6vw, 60px) clamp(28px, 7vw, 72px);
+      margin: 0 auto;
     }
 
     @media (max-width: 768px) {
+      body:not(.cta-aligned) #cta-stack {
+        max-width: calc(100% - 32px);
+        margin: 36px auto 52px;
+        gap: 20px;
+      }
+
       body:not(.cta-aligned) #cta-panel {
-        padding: 32px 24px;
+        max-width: 100%;
+        padding: 30px 22px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body:not(.cta-aligned) #cta-stack {
+        margin: 28px auto 40px;
+      }
+
+      body:not(.cta-aligned) #cta-panel {
+        padding: 26px 18px;
       }
     }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -101,9 +101,9 @@
     }
 
     body:not(.cta-aligned) #cta-stack {
-      max-width: min(736px, calc(100% - 64px));
+      max-width: min(664px, calc(100% - 72px));
       margin: 40px auto 52px;
-      gap: 22px;
+      gap: 20px;
     }
 
     #fab-stack {
@@ -251,22 +251,30 @@
     }
 
     body:not(.cta-aligned) #cta-panel {
-      max-width: min(672px, calc(100% - 64px));
+      max-width: min(604px, calc(100% - 72px));
       width: 100%;
-      padding: clamp(28px, 4.8vw, 48px) clamp(22px, 5.6vw, 58px);
+      padding: clamp(25px, 4.3vw, 44px) clamp(20px, 5vw, 52px);
       margin: 0 auto;
+    }
+
+    body.cta-aligned #cta-panel {
+      max-width: min(604px, calc(100% - 72px));
+      width: 100%;
+      padding: clamp(25px, 4.3vw, 44px) clamp(20px, 5vw, 52px);
+      margin: -50px auto 0;
     }
 
     @media (max-width: 768px) {
       body:not(.cta-aligned) #cta-stack {
-        max-width: calc(100% - 40px);
+        max-width: calc(100% - 44px);
         margin: 28px auto 42px;
         gap: 16px;
       }
 
-      body:not(.cta-aligned) #cta-panel {
+      body:not(.cta-aligned) #cta-panel,
+      body.cta-aligned #cta-panel {
         max-width: 100%;
-        padding: 24px 18px;
+        padding: 22px 16px;
       }
     }
 
@@ -275,13 +283,10 @@
         margin: 22px auto 32px;
       }
 
-      body:not(.cta-aligned) #cta-panel {
-        padding: 21px 14px;
+      body:not(.cta-aligned) #cta-panel,
+      body.cta-aligned #cta-panel {
+        padding: 19px 12px;
       }
-    }
-
-    body.cta-aligned #cta-panel {
-      margin-top: -50px;
     }
 
     body.cta-aligned #cta-button {
@@ -310,7 +315,7 @@
 
     @media (max-width: 767px) {
       body.cta-aligned #cta-panel {
-        padding-top: 50px;
+        padding-top: 45px;
       }
     }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -210,6 +210,11 @@
 
       .settings-actions {
         width: 100%;
+        align-items: center;
+      }
+
+      .settings-actions .simulator-access {
+        width: 50%;
       }
 
       body.cta-aligned #cta-stack {
@@ -303,6 +308,16 @@
 
     body.cta-aligned #cta-button {
       margin-top: -22px;
+    }
+
+    @media (max-width: 768px) {
+      body.cta-aligned #cta-panel {
+        margin: 24px auto 0;
+      }
+
+      body.cta-aligned #cta-button {
+        margin-top: 16px;
+      }
     }
 
     @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- Añadí los identificadores `#cta-panel` y `#cta-button` para fijar el objetivo del ajuste.
- Ajusté los márgenes responsivos del panel gris y el botón promocional para alinearlos con los botones de los extremos en escritorio y tablet, manteniendo un desplazamiento moderado en móvil.
- Apliqué un relleno superior en móviles para evitar que el contenido se superponga con los accesos rápidos.

## Testing
- Verifiqué manualmente el layout a 360px, 1024px y 1440px.


------
https://chatgpt.com/codex/tasks/task_e_68d1d3438a448320a3bb2a7a4ce0ccd2