### PR TITLE
Add Spotify promotional button

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -20,6 +20,7 @@
   const fabStack = document.getElementById('fab-stack');
   const settingsBtn = document.getElementById('settings-btn');
   const participateBtn = document.getElementById('participate-btn');
+  const spotifyBtn = document.getElementById('spotify-btn');
   const settingsModal = document.getElementById('settings-modal');
   const settingsCurrency = document.getElementById('settings-currency');
   const closeSettings = document.getElementById('close-settings');
@@ -48,6 +49,9 @@
   }
   if (participateBtn) {
     participateBtn.style.display = 'none';
+  }
+  if (spotifyBtn) {
+    spotifyBtn.style.display = 'none';
   }
   if (neoOfferWrapper) {
     neoOfferWrapper.style.display = 'none';
@@ -172,6 +176,9 @@
     if (participateBtn) {
       participateBtn.style.display = 'flex';
     }
+    if (spotifyBtn) {
+      spotifyBtn.style.display = 'flex';
+    }
     if (neoOfferWrapper) {
       neoOfferWrapper.style.display = 'block';
     }
@@ -245,6 +252,11 @@
   participateBtn?.addEventListener('click', () => {
     if (!currentUser) return;
     window.open('https://www.youtube.com/shorts/w9VK-NoK7Wg', '_blank');
+  });
+
+  spotifyBtn?.addEventListener('click', () => {
+    if (!currentUser) return;
+    window.open('https://www.spotify.com/mx/family/join/invite/8cZc5xC2Y8ZzaAb/', '_blank');
   });
 
   closeSettings.addEventListener('click', () => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -118,8 +118,15 @@
     currencySection.style.display = 'block';
   }
 
+  function formatNeo(value) {
+    return Number(value).toLocaleString('es-MX', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 4,
+    });
+  }
+
   function updateBalance() {
-    neoBalance.textContent = `${currentUser.balance} NEO`;
+    neoBalance.textContent = `${formatNeo(currentUser.balance)} NEO`;
   }
 
   function updateCurrencyUI() {
@@ -286,11 +293,11 @@
       showToast('tasa no disponible');
       return;
     }
-    const neo = Math.round(amount * neoPer);
-    currentUser.balance += neo;
+    const neo = Math.round(amount * neoPer * 10000) / 10000;
+    currentUser.balance = Math.round((currentUser.balance + neo) * 10000) / 10000;
     saveUsers();
     updateBalance();
-    showToast(`compraste ${neo} NEO`);
+    showToast(`compraste ${formatNeo(neo)} NEO`);
   });
 
   transferBtn.addEventListener('click', () => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -782,6 +782,15 @@
           </svg>
           <span class="settings-label">Participa</span>
         </button>
+        <button id="spotify-btn" class="settings fab fab-spotify" type="button" aria-label="Spotify" title="Spotify" style="display:none;">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="12" r="9"></circle>
+            <path d="M8.2 10.3c2.4-.7 5.2-.4 7.6.8"></path>
+            <path d="M8.9 12.8c1.9-.6 4.2-.3 6.1.6"></path>
+            <path d="M9.6 15.1c1.3-.4 2.9-.2 4.2.3"></path>
+          </svg>
+          <span class="settings-label">Spotify gratis un mes</span>
+        </button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add a Spotify floating action button matching the existing quick-action styling
- display the new button after login with a hover label advertising a free month
- open the provided Spotify invite link in a new tab when the button is clicked

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dbfa88d968832084c65bc84b3c6497